### PR TITLE
Support m.module and use oncreate instead of oninit

### DIFF
--- a/transforms/config/_output.js
+++ b/transforms/config/_output.js
@@ -13,7 +13,7 @@ m("div", {
         vnode.dom.style.color = "blue";
     },
 
-    oninit: function(vnode) {
+    oncreate: function(vnode) {
         vnode.dom.style.color = "red";
 
         return;

--- a/transforms/m-module/_input.js
+++ b/transforms/m-module/_input.js
@@ -1,0 +1,1 @@
+m.module(document.body, component);

--- a/transforms/m-module/_output.js
+++ b/transforms/m-module/_output.js
@@ -1,0 +1,1 @@
+m.mount(document.body, component);

--- a/transforms/m-module/index.js
+++ b/transforms/m-module/index.js
@@ -1,0 +1,18 @@
+"use strict";
+
+// https://github.com/lhorie/mithril.js/blob/rewrite/docs/v1.x-migration.md#mcomponent-removed
+// Convert `m.module()` invocations into `m.mount()`
+module.exports = function(file, api) {
+    var j = api.jscodeshift;
+
+    return j(file.source)
+        .find(j.MemberExpression, {
+          object: { name: "m" },
+          property: { name: "module" },
+        })
+        .replaceWith((p) => {
+            p.node.property.name = "mount";
+            return p.node;
+        })
+        .toSource();
+};


### PR DESCRIPTION
In the case of 0.x, "config" always has the dom element available. The correct lifecycle hook to replace !init if blocks would most likely be oncreate since oninit doesn't have the dom element available yet.