### PR TITLE
Make m.route.get/set transform safer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mithril-codemods",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Transform mithril@0.2.x code into mithril@1.x using jscodeshift",
   "main": "index.js",
   "bin": "./bin/cli.js",

--- a/transforms/m-route-get-set/_input.js
+++ b/transforms/m-route-get-set/_input.js
@@ -1,2 +1,3 @@
 m.route();
 m.route("/new-route");
+m.route(document.body, "/", {});

--- a/transforms/m-route-get-set/_output.js
+++ b/transforms/m-route-get-set/_output.js
@@ -1,2 +1,3 @@
 m.route.get();
 m.route.set("/new-route");
+m.route(document.body, "/", {});

--- a/transforms/m-route-get-set/index.js
+++ b/transforms/m-route-get-set/index.js
@@ -11,26 +11,21 @@ module.exports = function(file, api) {
             callee : {
                 object   : { name : "m" },
                 property : { name : "route" }
-            }
+            },
+
+            arguments : (node) => node.length < 2
         })
-        .replaceWith((p) => {
-            var args = p.get("arguments").value,
-                type = "get";
-
-            if(args.length) {
-                type = "set";
-            }
-
-            return j.callExpression(
+        .replaceWith((p) => j.callExpression(
+            j.memberExpression(
                 j.memberExpression(
-                    j.memberExpression(
-                        j.identifier("m"),
-                        j.identifier("route")
-                    ),
-                    j.identifier(type)
+                    j.identifier("m"),
+                    j.identifier("route")
                 ),
-                args
-            );
-        })
+                j.identifier(
+                    p.get("arguments").getValueProperty("length") ? "set" : "get"
+                )
+            ),
+            p.get("arguments").value
+        ))
         .toSource();
 };


### PR DESCRIPTION
Shouldn't run if m.route has more than 1 arg because we only care about the 0/1 arguments cases.

Fixes #11